### PR TITLE
Fix verifyDetached error handling

### DIFF
--- a/command_verify.go
+++ b/command_verify.go
@@ -124,7 +124,7 @@ func verifyDetached() error {
 		f = stdin
 	} else {
 		if f, err = os.Open(fileArgs[1]); err != nil {
-			errors.Wrapf(err, "failed to open message file (%s)", fileArgs[1])
+			return errors.Wrapf(err, "failed to open message file (%s)", fileArgs[1])
 		}
 		defer f.Close()
 	}


### PR DESCRIPTION
## Summary
- return wrapped error when verifyDetached fails to open message file

## Testing
- `go test ./...` *(fails: CERTSTORE_DOESNT_WORK_ON_LINIX build error)*

------
https://chatgpt.com/codex/tasks/task_e_6842a4f109d48322b269ed1ac0eb566d