### PR TITLE
Add landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>smimesign - Secure Code Signing</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2em;
+            line-height: 1.5;
+        }
+        header {
+            text-align: center;
+            margin-bottom: 2em;
+        }
+        h1 {
+            color: #333;
+        }
+        .features {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1em;
+        }
+        .feature {
+            flex: 1 1 200px;
+            border: 1px solid #eee;
+            padding: 1em;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Welcome to smimesign</h1>
+        <p>Sign your code with ease while keeping your workflow secure.</p>
+    </header>
+    <section class="features">
+        <div class="feature">
+            <h2>Code Integration</h2>
+            <p>Seamlessly sign Git commits and tags directly from your terminal.</p>
+        </div>
+        <div class="feature">
+            <h2>Security</h2>
+            <p>Use trusted S/MIME certificates to verify authorship and integrity.</p>
+        </div>
+        <div class="feature">
+            <h2>Debugging</h2>
+            <p>Verbose output and clear errors help resolve signing issues fast.</p>
+        </div>
+        <div class="feature">
+            <h2>Documentation</h2>
+            <p>Guides and examples demonstrate best practices for secure signing.</p>
+        </div>
+        <div class="feature">
+            <h2>Testing</h2>
+            <p>Automated tests keep your signing process reliable across platforms.</p>
+        </div>
+    </section>
+    <footer>
+        <p>Get started with smimesign today and protect your code.</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/index.html` as a simple landing page highlighting code integration, security, debugging, documentation, and testing benefits

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f8cba28548322b6d3e6679abbad8f